### PR TITLE
PENALTYを次の問題に引き継ぐのは変なので、user_id,problem_idの両方でPENALTYを管理する。

### DIFF
--- a/app/channels/match_channel.rb
+++ b/app/channels/match_channel.rb
@@ -6,22 +6,23 @@ class MatchChannel < ApplicationCable::Channel
 
     stream_from user_room(user_id) #各自用
 
+    # FIXME: RoomQueueは人数に関心を持つべき。
     room_queue = RoomQueue.new(room_key: match_room_name)
 
     # OPTIMIZE: 対戦サーバーが取り出してマッチングさせてもいいかも。
     return if room_queue.push(user_id) < player_count
-    return unless players = room_queue.get_players(player_count)
+    return unless user_ids = room_queue.get_players(player_count)
 
     # 部屋の成立 ここらへんYAGNIな気も
     room = Room.new(
-      players: players,
+      user_ids: user_ids,
       level: params[:level],
       category: category
     ).save
 
-    players.each do |player|
-      start_match(player, players.reject{|e|e==player}, room.id)
-      User.new(id: player, problems: []).save
+    user_ids.each do |user_id|
+      start_match(user_id, user_ids.reject{|e|e==user_id}, room.id)
+      User.new(id: user_id, problems: []).save
     end
   end
 

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -1,21 +1,22 @@
 class RoomChannel < ApplicationCable::Channel
   PROBLEM_NUMBER = 10
-  WRONG_ANSWER_PENALTY_SECONDS = 5
-  def subscribed
+  WRONG_ANSWER_PENALTY_SECONDS = 3
+  def subscribed 
     room = Room.find!(params[:room_id])
     room.join!(params[:user_id])
 
     stream_from user_channel # ユーザーと1on1のstream
     stream_from room_channel # ルーム内全員
     return unless room.match?
-    return unless room.can_start?
+    return unless room.can_start? #既に始まっているかどうか
 
-    # TODO: 全員集まったら部屋を消す感じにしてるけど、リロードしたときに死ぬから、room_id、user_idの一致で問題を再配信するくらいの親切さがほしい。
-    # 実装としては部屋情報がなければ次に進む。あればそれを返すって感じかな。誰が何を解いたかも含めて上げる必要がある。問題と、各ユーザーが解いた問題の集合を渡す
+    # TODO: 全員集まったら部屋を入れなくしていて、リロードしたときに死ぬから、room_id、user_idの一致で問題を再配信するくらいの親切さがほしい。
+    # 実装としてはroom_idの最後に配信した問題を再配信するという感じかな。
+
     ActionCable.server.broadcast room_channel, message: "試合開始！", type: "gameStart"
 
-    # TODO: カテゴリに合ったランキングを取得する仕組み allじゃなくてidで絞り込む実装
     # NOTE: 各問題の要素数、だんだん増えていくと競技として面白そう。
+    # TODO: 問題が作られるのはランキングからだけでなく、数字、文字列から作られる可能性がある。Problemが共通のフォーマットとしてありたい。
     room.problem_ids = Ranking.create_problems(PROBLEM_NUMBER, room.level*4, room.category).map(&:id)
     deliver_problem room.pop_problem
   rescue StandardError => e
@@ -32,7 +33,7 @@ class RoomChannel < ApplicationCable::Channel
     problem = Problem.find!(hash["problem_id"])
     user = User.find!(params[:user_id])
 
-    unless room.can_submit?(params[:user_id])
+    unless room.can_submit?(user.id,problem.id)
       ActionCable.server.broadcast user_channel, {
         message: "#{WRONG_ANSWER_PENALTY_SECONDS}秒以内に再提出はできません",
         type: "penalty"
@@ -41,15 +42,18 @@ class RoomChannel < ApplicationCable::Channel
 
     # 最初の人のみがdelete==1
     if problem.correct?(hash["answer"]) && problem.delete == 1
-      ActionCable.server.broadcast room_channel, message: "#{params[:user_id]}さんが「#{problem.name}」を解きました", type: "notice"
+      ActionCable.server.broadcast room_channel, message: "#{user.id}さんが「#{problem.name}」を解きました", type: "notice"
       user.add_problem(problem) # TODO: socreの計算ロジック
-      return if deliver_problem room.pop_problem 
+      return if deliver_problem room.pop_problem
 
       ActionCable.server.broadcast room_channel, message: "ゲーム終了です", result: "#{room.result.to_json}", type: "gameEnd"
     else
       ActionCable.server.broadcast user_channel, message: "不正解です", type: "wrongAnswer"
-      room.disable_submit(params[:user_id],WRONG_ANSWER_PENALTY_SECONDS)
+      room.disable_submit(user.id,problem.id,WRONG_ANSWER_PENALTY_SECONDS)
     end
+  rescue StandardError => e
+    ActionCable.server.broadcast user_channel, message: e if Rails.env.development?
+    raise e
   end
 
   private


### PR DESCRIPTION
- 無駄にuserがplayerという言葉を使っていたことがあった
- user objectを持っているのかidを持っているのかわかりにくいので、user_idと変数名を明確にした。
- PENALTYをuser_idだけに紐付かないようにして、別の問題ではPENALTYがない状態にした。

#18 