### PR TITLE
Add timeout

### DIFF
--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -2,46 +2,56 @@ class RoomChannel < ApplicationCable::Channel
   PROBLEM_NUMBER = 10
   WRONG_ANSWER_PENALTY_SECONDS = 3
   NETWORK_DEFERRED_CONSIDERATION_SECONDS = 1
+  TIMEOUT_SECONDS = 30
 
   def subscribed
-    room = Room.find!(params[:room_id])
-    room.join!(params[:user_id])
+    @room = Room.find!(params[:room_id])
+    @room.join!(params[:user_id])
 
     stream_from user_channel # ユーザーと1on1のstream
     stream_from room_channel # ルーム内全員
-    return unless room.match?
-    return unless room.can_start? # 既に始まっているかどうか
+    return unless @room.match?
+    return unless @room.can_start? # 既に始まっているかどうか
 
     # TODO: 全員集まったら部屋を入れなくしていて、リロードしたときに死ぬ
     ActionCable.server.broadcast room_channel, message: '試合開始！', type: 'gameStart'
     # NOTE: 各問題の要素数、だんだん増えていくと競技として面白そう。
 
-    rankings = Category.find(room.category).sample_rankings(PROBLEM_NUMBER)
-    room.problem_ids = rankings.map do |r|
+    rankings = Category.find(@room.category).sample_rankings(PROBLEM_NUMBER)
+    @room.problem_ids = rankings.map do |r|
       Problem.create(
         name: r.name,
         elements: r.elements.split(','),
-        size: room.level * 4 # TODO: roomがsize直で持つべきやな、、、。
+        size: @room.level * 4 # TODO: roomがsize直で持つべきやな、、、。
       ).id
     end
 
-    deliver_problem room.pop_problem
+    deliver_problem @room.pop_problem
   rescue StandardError => e
     ActionCable.server.broadcast user_channel, message: e if Rails.env.development?
     raise e
   end
 
   def unsubscribed
-    # Any cleanup needed when channel is unsubscribed
+    # 退出しました的なメッセージを出せる
   end
 
   def submit(hash)
-    room = Room.find!(params[:room_id])
+    @room = Room.find!(params[:room_id])
     # TODO: 既に問題を解かれた人がここでエラーになる。クライアントに何も送信しないから問題はないけど、ログが汚れるから治そう
     problem = Problem.find!(hash['problem_id'])
     user = User.find!(params[:user_id])
 
-    unless room.can_submit?(user.id, problem.id)
+    if problem.timeout?
+      sleep NETWORK_DEFERRED_CONSIDERATION_SECONDS # to avoid timeouter delete probelem before winner do
+      return unless problem.delete
+      ActionCable.server.broadcast user_channel,
+        message: '正解者はいませんでした。',
+        type: 'noWinner'
+      return deliver_problem @room.pop_problem
+    end
+
+    unless @room.can_submit?(user.id, problem.id)
       ActionCable.server.broadcast(
         user_channel,
         message: "#{WRONG_ANSWER_PENALTY_SECONDS}秒以内に再提出はできません",
@@ -51,7 +61,7 @@ class RoomChannel < ApplicationCable::Channel
 
     unless problem.correct?(hash['answer'])
       ActionCable.server.broadcast user_channel, message: '不正解です', type: 'wrongAnswer'
-      room.disable_submit(user.id, problem.id, WRONG_ANSWER_PENALTY_SECONDS)
+      @room.disable_submit(user.id, problem.id, WRONG_ANSWER_PENALTY_SECONDS)
       return
     end
 
@@ -63,17 +73,12 @@ class RoomChannel < ApplicationCable::Channel
     win_user = User.find!(ac_user_id)
 
     ActionCable.server.broadcast room_channel,
-                                 message: "#{win_user.id}さんが「#{problem.name}」を解きました",
-                                 type: 'notice'
+      message: "#{win_user.id}さんが「#{problem.name}」を解きました",
+      type: 'notice'
 
     win_user.add_problem(problem) # TODO: socreの計算ロジック
 
-    return if deliver_problem room.pop_problem
-
-    ActionCable.server.broadcast room_channel,
-                                 message: 'ゲーム終了です',
-                                 result: room.result.to_json.to_s,
-                                 type: 'gameEnd'
+    deliver_problem @room.pop_problem
   rescue StandardError => e
     ActionCable.server.broadcast user_channel, message: e if Rails.env.development?
     raise e
@@ -81,13 +86,18 @@ class RoomChannel < ApplicationCable::Channel
 
   private
     def deliver_problem(problem_id)
-      return nil unless problem_id
-
-      problem = Problem.find!(problem_id)
-      ActionCable.server.broadcast room_channel,
-                                   problem: problem.to_client,
-                                   type: 'deliverProblem'
-      true
+      if problem_id
+        problem = Problem.find!(problem_id)
+        problem.set_timeout TIMEOUT_SECONDS
+        ActionCable.server.broadcast room_channel,
+          problem: problem.to_client,
+          type: 'deliverProblem'
+      else
+        ActionCable.server.broadcast room_channel,
+          message: 'ゲーム終了です',
+          result: @room.result.to_json.to_s,
+          type: 'gameEnd'
+      end
     end
 
     def room_channel

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -55,12 +55,13 @@ class RoomChannel < ApplicationCable::Channel
       ActionCable.server.broadcast(
         user_channel,
         message: "#{WRONG_ANSWER_PENALTY_SECONDS}秒以内に再提出はできません",
-        type: 'penalty'
+        type: 'penalty',
+        ttl_ms: problem.remain_milliseconds
       ) && return
     end
 
     unless problem.correct?(hash['answer'])
-      ActionCable.server.broadcast user_channel, message: '不正解です', type: 'wrongAnswer'
+      ActionCable.server.broadcast user_channel, message: '不正解です', type: 'wrongAnswer', ttl_ms: problem.remain_milliseconds
       @room.disable_submit(user.id, problem.id, WRONG_ANSWER_PENALTY_SECONDS)
       return
     end

--- a/app/models/application_redis/problem.rb
+++ b/app/models/application_redis/problem.rb
@@ -3,14 +3,13 @@ class Problem < ApplicationRedis
 
   def self.create(name:, elements:, size:)
     indices = [*0..(elements.size-1)].sample(size).sort
-    p ordered_elements = elements.values_at(*indices)
-    answer = ordered_elements.join('|')
+    ordered_elements = elements.values_at(*indices)
     new(
       id: SecureRandom.uuid,
       name: name,
       right_elements: ordered_elements,
       elements: ordered_elements.shuffle,
-      answer: answer
+      answer: ordered_elements.join('|')
     ).save
   end
 
@@ -24,6 +23,14 @@ class Problem < ApplicationRedis
 
   def correct?(sub)
     answer == sub
+  end
+
+  def set_timeout(seconds)
+    REDIS.setex(expire_key, seconds, "I'm alive")
+  end
+
+  def timeout?
+    !REDIS.exists(expire_key)
   end
 
   def push_solved_user(user_id, required_time)
@@ -40,5 +47,9 @@ class Problem < ApplicationRedis
   private
     def solved_user_key
       "solved-#{id}"
+    end
+
+    def expire_key
+      "problem-expire-#{id}"
     end
 end

--- a/app/models/application_redis/problem.rb
+++ b/app/models/application_redis/problem.rb
@@ -29,6 +29,10 @@ class Problem < ApplicationRedis
     REDIS.setex(expire_key, seconds, "I'm alive")
   end
 
+  def remain_milliseconds
+    REDIS.pttl(expire_key)
+  end
+
   def timeout?
     !REDIS.exists(expire_key)
   end

--- a/app/models/room_queue.rb
+++ b/app/models/room_queue.rb
@@ -15,7 +15,7 @@ class RoomQueue
   # 有効なプレイヤーを返す。内部的には一旦取り出して、切断されていたらならキューの先頭に詰め直している。
   def get_players(player_number)
     players = player_number.times.map { REDIS.rpop(room_key) }
-    alives, deads = players.partition { |e|user_enabled?(e) }
+    alives, _deads = players.partition { |e|user_enabled?(e) }
     if alives.size != player_number
       alives.each { |e|REDIS.rpush(room_key, e) }
       nil
@@ -28,16 +28,16 @@ class RoomQueue
     REDIS.del(room_user_key(user_id))
   end
 
-    private
-      def room_user_key(user_id)
-        room_key+'-'+user_id
-      end
+  private
+    def room_user_key(user_id)
+      room_key+'-'+user_id
+    end
 
-      def enable_user(user_id)
-        REDIS.set(room_user_key(user_id), 'alive')
-      end
+    def enable_user(user_id)
+      REDIS.set(room_user_key(user_id), 'alive')
+    end
 
-      def user_enabled?(user_id)
-        REDIS.exists(room_user_key(user_id))
-      end
+    def user_enabled?(user_id)
+      REDIS.exists(room_user_key(user_id))
+    end
 end

--- a/app/models/room_queue.rb
+++ b/app/models/room_queue.rb
@@ -1,43 +1,43 @@
 class RoomQueue
-    attr_accessor :room_key 
-    def initialize(h)
-        self.room_key = h[:room_key]    
-    end
+  attr_accessor :room_key
+  def initialize(h)
+    self.room_key = h[:room_key]
+  end
 
-    # return list length
-    def push(user_id)
-        # リストに入っている間にユーザーが死ぬ可能性があるので生死の管理をする
-        enable_user(user_id)
-        # 後から来た人が左から詰められる
-        REDIS.lpush(room_key, user_id)
-    end
+  # return list length
+  def push(user_id)
+    # リストに入っている間にユーザーが死ぬ可能性があるので生死の管理をする
+    enable_user(user_id)
+    # 後から来た人が左から詰められる
+    REDIS.lpush(room_key, user_id)
+  end
 
-    # 有効なプレイヤーを返す。内部的には一旦取り出して、切断されていたらならキューの先頭に詰め直している。
-    def get_players(player_number)
-        players = player_number.times.map{REDIS.rpop(room_key)}
-        alives, deads = players.partition{|e|user_enabled?(e)}
-        if alives.size != player_number
-            alives.each{|e|REDIS.rpush(room_key, e)}
-            nil
-        else
-            alives.each{|e|disable_user(e)}
-        end
+  # 有効なプレイヤーを返す。内部的には一旦取り出して、切断されていたらならキューの先頭に詰め直している。
+  def get_players(player_number)
+    players = player_number.times.map { REDIS.rpop(room_key) }
+    alives, deads = players.partition { |e|user_enabled?(e) }
+    if alives.size != player_number
+      alives.each { |e|REDIS.rpush(room_key, e) }
+      nil
+    else
+      alives.each { |e|disable_user(e) }
     end
+  end
 
-    def disable_user(user_id)
-        REDIS.del(room_user_key(user_id))
-    end
+  def disable_user(user_id)
+    REDIS.del(room_user_key(user_id))
+  end
 
     private
-    def room_user_key(user_id)
-        room_key+"-"+user_id
-    end
+      def room_user_key(user_id)
+        room_key+'-'+user_id
+      end
 
-    def enable_user(user_id)
-        REDIS.set(room_user_key(user_id),"alive")
-    end
-    
-    def user_enabled?(user_id)
+      def enable_user(user_id)
+        REDIS.set(room_user_key(user_id), 'alive')
+      end
+
+      def user_enabled?(user_id)
         REDIS.exists(room_user_key(user_id))
-    end
+      end
 end


### PR DESCRIPTION
時間制限を追加した。REDISにゆうこうきげんのキーをもたせておいて、なくなったら正解者なし。

よく考えたら、同じ時間かけて解いた人がいたとして、ネットワークの遅れで提出が遅れた人は、時間制限に弾かれる実装になってるけど、さすがにそこまで面倒みる必要はない。

相変わらずdelete頼みでデータの不整合を防いでいる（回答と没収試合の両立はない）

クライアント側でttl受け取って表示してもいいかなと思ったけど、サーバー・クライアントの間の時差があるのでそのまま表示しても若干遅れるけど、それはそれかな。